### PR TITLE
Fix extra whitespace

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,7 +63,7 @@ If you're using [[https://github.com/radian-software/straight.el][straight.el]] 
         :ANKI_NOTE_TYPE: Basic
         :END:
 
-      ,** Back
+     ,** Back
 
         Yes, like this one, Front is missing, ~anki-editor~ will use note
         heading as Front.  This is neat as sometimes it's verbose to repeat
@@ -71,12 +71,12 @@ If you're using [[https://github.com/radian-software/straight.el][straight.el]] 
 
         This works for all note types, just make one field absent and
         ~anki-editor~ will use note heading as that missing field.
-     
+
      ,* Is there a an even shorter way to write notes?
         :PROPERTIES:
         :ANKI_NOTE_TYPE: Basic
         :END:
-        
+
         Yes, like this one, Front and Back is missing, ~anki-editor~ will use note
         heading as Front and the text after as Back.  This is neat as sometimes it's verbose to repeat
         the same content in note heading and first field.


### PR DESCRIPTION
Due to extra whitespace before the asterisk, the ` ** Back` heading in the example wasn't recognized as an org heading. I noticed that when I copied the example from github into an org buffer, it looked like the screenshot below (with `org-modern` mode). Other whitespace changes are just cosmetical, automatically done by whitespace-cleanup in emacs.
![image](https://user-images.githubusercontent.com/5121824/214267658-5a40e76c-9f47-4c8a-8567-479672acbe7c.png)
